### PR TITLE
feat (zodiac-sign): add month animal to zodiac sign query

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -43,4 +43,3 @@ app.register_blueprint(api_blueprint)
 
 from app import routes
 from app.api import views
-

--- a/app/api/schema/__init__.py
+++ b/app/api/schema/__init__.py
@@ -1,2 +1,3 @@
 from .month_signs import month_signs_schema
 from .year_signs import year_signs_schema
+from .year_signs import signs_schema

--- a/app/api/schema/year_signs.py
+++ b/app/api/schema/year_signs.py
@@ -3,6 +3,7 @@ import ast
 
 from app.api import signs_ns
 from flask_restplus import fields
+from .month_signs import month_signs_schema
 
 
 class FormatNested(fields.Raw):
@@ -39,4 +40,12 @@ year_signs_schema = {
     'report': FormatNested(attribute='report', description="Sign's report"),
 }
 
+signs_schema = year_signs_schema.copy()
 year_signs_schema = signs_ns.model('Zodiacs', year_signs_schema)
+
+
+signs_schema.update({
+    'month': fields.Nested(month_signs_schema, skip_none=True,
+                           attribute="month", description="Sign's month details"),
+})
+signs_schema = signs_ns.model('Zodiacs', signs_schema)

--- a/app/forms.py
+++ b/app/forms.py
@@ -3,6 +3,7 @@ from wtforms import (BooleanField, IntegerField, PasswordField, StringField,
                      SubmitField)
 from wtforms.validators import DataRequired, Email, EqualTo, ValidationError
 
+
 from app.models import User
 
 

--- a/tests/signs/test_sign_get_endpoints.py
+++ b/tests/signs/test_sign_get_endpoints.py
@@ -10,6 +10,24 @@ BASE_URL = AppConfig.API_BASE_URL_V1
 class TestGetSignDetails:
     """Test for the get sign details endpoint"""
 
+    def test_list_signs_succeeds(
+            self, client, init_db, new_test_sign):
+        """
+        Test that sign details are successfully returned when a valid
+        sign id is provided
+        """
+        new_test_sign.save()
+        response = client.get(
+            f'{BASE_URL}/signs/year/')
+        response_json = json.loads(response.data.decode("utf-8"))
+
+        assert response.status_code == 200
+        sign_data = response_json['signs']
+        assert type(sign_data) == list
+        assert sign_data[0]['id'] == new_test_sign.id
+        assert sign_data[0]['name'] == new_test_sign.name
+        assert sign_data[0]['element'] == new_test_sign.element
+
     def test_get_sign_with_valid_id_succeeds(
             self, client, init_db, new_test_sign):
         """


### PR DESCRIPTION
**What does this PR do?**

- [x] Add month to zodiac sign query
- [x] Write tests for the finctionality

**Description of Task to be completed?**

urrently, when a query for the relevant zodiac sign (By passing date of birth) is made, It does not include the month's zodiac sign
- This PR adds that field


**How should this be manually tested?**

- Clone this repo using the command `git clone https://github.com/rivendale/ethsigns.git`
- Create a local copy of this branch by running `git fetch ft-sign-query-13`
- Checkout to the branch `git checkout ft-sign-query-13`
- Start the application with the command: `flask run`
- Navigate to the documentation `{base-url}/api/v1/signs/query/?year=2010&month=2&day=3`

**Any background context you want to provide?**

N/A

**What are the relevant github issue**

N/A


**Screenshots (if appropriate)**

N/A


**Questions:**

N/A
